### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/flasksetup.py
+++ b/flasksetup.py
@@ -77,9 +77,11 @@ def scrape():
         })
 
     except Exception as e:
+        import logging
+        logging.error("An error occurred: %s", str(e), exc_info=True)
         return jsonify({
             'success': False,
-            'error': str(e)
+            'error': 'An internal error has occurred. Please try again later.'
         }), 500
 
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/beeboy11/WebSage/security/code-scanning/2](https://github.com/beeboy11/WebSage/security/code-scanning/2)

To fix the issue, the code should be modified to ensure that the exception details are not exposed to the user. Instead, a generic error message should be returned in the JSON response, and the detailed exception information should be logged on the server for debugging purposes. This can be achieved by using Python's `logging` module to log the exception details and replacing the user-facing error message with a generic one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
